### PR TITLE
📌 Add GET endpoint for arrests data ('/api/arrests')

### DIFF
--- a/api/src/api/arrests.js
+++ b/api/src/api/arrests.js
@@ -1,9 +1,10 @@
 const router = require('express').Router();
 const Incident = require('../models/Incident');
 
-const VICTIM_ARREST_FOCUSES = [
+// constant list of arrests that qualify as victim arrests
+const VICTIM_ARREST_FOCUSES = Object.freeze([
 	"Prostitution Arrests or Stings"
-]
+])
 
 function getStatsFromArrests(arrests) {
 
@@ -36,9 +37,10 @@ router.get('*', async (req, res) => {
 	}
 	if (req.query.time_range) {
 
-		const [startYear, endYear] = req.query.time_range.split(',');
+		const [startYear, endYear] = req.query.time_range.split(',')
+			.map(elem => Number(elem))
 
-		if (!isNaN(Number(startYear)) && !isNaN(Number(endYear))) {
+		if (!isNaN(startYear) && !isNaN(endYear)) {
 			query.dateOfOperation = {
 				$gte: Number(startYear)
 			};

--- a/api/src/api/arrests.js
+++ b/api/src/api/arrests.js
@@ -16,9 +16,15 @@ function getStatsFromArrests(arrests) {
 		.reduce((accumulator, arrest) => accumulator + arrest)
 	}
 
+	let arrestScore = Number(((arrests.length - victimArrestCount) / arrests.length * 100).toFixed(2));
+
+	if (isNaN(arrestScore)) {
+		arrestScore = -1;
+	}
+
 	return {
-		arrestScore: Number(((arrests.length - victimArrestCount) / arrests.length * 100).toFixed(2)),
-		victimArrestCount: victimArrestCount,
+		arrestScore,
+		victimArrestCount,
 		traffickerArrestCount: arrests.length - victimArrestCount,
 		totalCaseCount: arrests.length
 	}

--- a/api/src/api/arrests.js
+++ b/api/src/api/arrests.js
@@ -42,10 +42,10 @@ router.get('*', async (req, res) => {
 
 		if (!isNaN(startYear) && !isNaN(endYear)) {
 			query.dateOfOperation = {
-				$gte: Number(startYear)
+				$gte: new Date(startYear, 0, 1, 0, 0, 0, 0).getTime()
 			};
 			query.endDateOfOperation = {
-				$lte: Number(endYear)
+				$lte: new Date(endYear, 11, 31, 0, 0, 0, 0).getTime()
 			};
 		}
 	}

--- a/api/src/api/arrests.js
+++ b/api/src/api/arrests.js
@@ -36,14 +36,14 @@ router.get('*', async (req, res) => {
 	}
 	if (req.query.time_range) {
 
-		const [startDate, endDate] = req.query.time_range.split(',');
+		const [startYear, endYear] = req.query.time_range.split(',');
 
-		if (!isNaN(Number(startDate)) && !isNaN(Number(endDate))) {
+		if (!isNaN(Number(startYear)) && !isNaN(Number(endYear))) {
 			query.dateOfOperation = {
-				$gte: startDate
+				$gte: Number(startYear)
 			};
 			query.endDateOfOperation = {
-				$lte: endDate
+				$lte: Number(endYear)
 			};
 		}
 	}

--- a/api/src/api/arrests.js
+++ b/api/src/api/arrests.js
@@ -1,0 +1,56 @@
+const router = require('express').Router();
+const Incident = require('../models/Incident');
+
+const VICTIM_ARREST_FOCUSES = [
+	"Prostitution Arrests or Stings"
+]
+
+function getStatsFromArrests(arrests) {
+
+	let victimArrestCount = 0;
+
+	if (arrests.length > 0) {
+		victimArrestCount = arrests
+		.map(arrest => VICTIM_ARREST_FOCUSES.includes(arrest.focus) ? 1 : 0)
+		.reduce((accumulator, arrest) => accumulator + arrest)
+	}
+
+	return {
+		arrestScore: Number(((arrests.length - victimArrestCount) / arrests.length * 100).toFixed(2)),
+		victimArrestCount: victimArrestCount,
+		traffickerArrestCount: arrests.length - victimArrestCount,
+		totalCaseCount: arrests.length
+	}
+
+}
+
+router.get('*', async (req, res) => {
+
+	const query = {};
+
+	if (req.query.city) {
+		query.city = req.query.city;
+	}
+	if (req.query.state) {
+		query.state = req.query.state;
+	}
+	if (req.query.time_range) {
+
+		const [startDate, endDate] = req.query.time_range.split(',');
+
+		if (!isNaN(Number(startDate)) && !isNaN(Number(endDate))) {
+			query.dateOfOperation = {
+				$gte: startDate
+			};
+			query.endDateOfOperation = {
+				$lte: endDate
+			};
+		}
+	}
+
+	const arrests = await Incident.find(query)
+	const stats = getStatsFromArrests(arrests)
+	res.send(stats)
+})
+
+module.exports = router;

--- a/api/src/api/index.js
+++ b/api/src/api/index.js
@@ -1,6 +1,8 @@
 const router = require('express').Router();
 const incidents = require('./incidents');
+const arrests = require('./arrests');
 
 router.use('/incidents', incidents);
+router.use('/arrests', arrests);
 
 module.exports = router;

--- a/api/src/utils/trafficker_arrest_parser.js
+++ b/api/src/utils/trafficker_arrest_parser.js
@@ -1,0 +1,39 @@
+/*
+ * this script is used to parse the provided
+ * mock data for trafficker arrests related to human trafficking
+ */
+
+const XLSX = require('xlsx');
+const path = require('path');
+const mongoose = require('mongoose');
+const Incident = require('../models/Incident');
+require('dotenv').config();
+
+mongoose.connect(process.env.MONGO_URI || 'mongodb://127.0.0.1:27017', {
+  useNewUrlParser: true,
+  useUnifiedTopology: true,
+});
+
+function main() {
+  const workbook = XLSX.readFile(path.join(__dirname, './incidents.xlsx'));
+  const worksheet = workbook.Sheets[workbook.SheetNames[4]];
+
+  const json = XLSX.utils.sheet_to_json(worksheet);
+
+  for (const incident of json) {
+    let newIncident = new Incident({
+      focus: incident['Content/Focus'],
+      caseTag: incident['Case Tag'],
+      dateOfOperation: incident['Date of Operation'],
+      endDateOfOperation: incident['Date of Operation'],
+      operationType: incident['Business Type'],
+      city: incident['Business City'],
+      state: incident['Business State'],
+      notes: incident["Add'l Note"],
+    });
+
+    newIncident.save();
+  }
+}
+
+main();

--- a/api/src/utils/victim_arrest_parser.js
+++ b/api/src/utils/victim_arrest_parser.js
@@ -1,0 +1,39 @@
+/*
+ * this script is used to parse the provided
+ * mock data for victim arrests related to human trafficking
+ */
+
+const XLSX = require('xlsx');
+const path = require('path');
+const mongoose = require('mongoose');
+const Incident = require('../models/Incident');
+require('dotenv').config();
+
+mongoose.connect(process.env.MONGO_URI || 'mongodb://127.0.0.1:27017', {
+  useNewUrlParser: true,
+  useUnifiedTopology: true,
+});
+ 
+function main() {
+  const workbook = XLSX.readFile(path.join(__dirname, './incidents.xlsx'));
+  const worksheet = workbook.Sheets[workbook.SheetNames[3]];
+
+  const json = XLSX.utils.sheet_to_json(worksheet);
+
+  for (const incident of json) {
+    let newIncident = new Incident({
+      focus: incident['Content/Focus'],
+      caseTag: incident['Case Tag'],
+      dateOfOperation: incident['Date of Operation'],
+      endDateOfOperation: incident['Date of Operation'],
+      operationType: incident['Operation Type'],
+      city: incident['Business City'],
+      state: incident['Business State'],
+      notes: "",
+    });
+
+    newIncident.save();
+  }
+}
+
+main();


### PR DESCRIPTION
### Changes

- Added route `/api/arrests` to return arrest statistics for the provided query on GET
- Query parameters:
    - city: string
    - state: string
    - time_range: string
        - ~~⚠️ this query param will not work until dates are stored as numbers instead of strings~~ **(Resolved by #41)**
        - In the format: \`TIME_A,TIME_B\` where each TIME_* is a string representation of an integer for a year
        - e.g. `TIME_A = "2010"` and `TIME_B = "2020"`
- Added two utility scripts to import victim and trafficker arrests as Incidents

#### Updates (10/30/20)

- dates are compared in ms since unix epoch
- if there is no data available `arrestScore` is -1 (instead of null)

### Valid request example:
`/api/arrests?city=Springfield&state=Massachusetts&time_range=2011,2019`

---

Addresses Issue #39 