### PR TITLE
🚨 Fix Vacatur Laws Memory Leak

### DIFF
--- a/client/src/components/VacaturSidebar.jsx
+++ b/client/src/components/VacaturSidebar.jsx
@@ -81,7 +81,7 @@ const VacaturSidebar = (props: Props) => {
 
   useEffect(() => {
     setAllVacaturColors();
-  }, [setAllVacaturColors]);
+  }, []);
 
   return (
     <>


### PR DESCRIPTION
### Changes

- Removed `setAllVacaturColors` as a dependency of its own calling in hook
